### PR TITLE
Registry login and push on master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ language: generic
 services:
     - docker
 
-before_install:
-    - make login
-
 script:
     - make build
 
 deploy:
     provider: script
-    script: make push 
+    script: make login && make push
     on:
         branch: master


### PR DESCRIPTION
This PR moves the registry login so it only happens on merges to master. 

Travisci doesn't make encrypted vars available when PR's come from outside the owning repo for security (makes sense) https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restriction